### PR TITLE
Only blur before click on Android

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -295,7 +295,8 @@
 		var clickEvent, touch;
 
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
-		if (document.activeElement && document.activeElement !== targetElement) {
+                // Limit to Android devices to avoid unnecessary breakage in code expecting blur after click (#350)
+		if (deviceIsAndroid && document.activeElement && document.activeElement !== targetElement) {
 			document.activeElement.blur();
 		}
 


### PR DESCRIPTION
Calling blur before dispatching the click event causes the blur event to
fire before the click event, rather than after as would be the case with
a browser click event.  This can cause issues in other code such as
twitter/typeahead.js#792.

This commit limits the unexpected event order to Android platforms,
where it is required for proper focus behavior (#24).

Signed-off-by: Kevin Locke kevin@kevinlocke.name
