### PR TITLE
New input types / Avoid moving cursor to end on focus

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -250,7 +250,11 @@
 			}
 
 			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
-			if (((target.type === 'text') || (target.type === 'email')) && target.value.length > 0) {
+			if (((target.type === 'text') || (target.type === 'email') ||
+				(target.type === 'date') || (target.type === 'time') ||
+				(target.type === 'datetime') || (target.type === 'datetime-local') ||
+				(target.type === 'tel') || (target.type === 'week') ||
+				(target.type === 'number')) && target.value.length > 0) {
 				return true;
 			}
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -230,8 +230,14 @@
 		// Don't send a synthetic click to disabled inputs (issue #62)
 		case 'button':
 		case 'select':
-		case 'textarea':
+			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
 			if (target.disabled) {
+				return true;
+			}
+			break;
+		case 'textarea':
+			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
+			if (target.disabled || target.value.length > 0) {
 				return true;
 			}
 
@@ -240,6 +246,11 @@
 
 			// File inputs need real clicks on iOS 6 due to a browser bug (issue #68)
 			if ((deviceIsIOS && target.type === 'file') || target.disabled) {
+				return true;
+			}
+
+			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
+			if ((target.type === 'text') && target.value.length > 0) {
 				return true;
 			}
 
@@ -263,7 +274,8 @@
 	FastClick.prototype.needsFocus = function(target) {
 		switch (target.nodeName.toLowerCase()) {
 		case 'textarea':
-			return true;
+			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
+			return (target.value.length == 0);
 		case 'select':
 			return !deviceIsAndroid;
 		case 'input':
@@ -278,7 +290,8 @@
 			}
 
 			// No point in attempting to focus disabled inputs
-			return !target.disabled && !target.readOnly;
+			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
+			return !target.disabled && !target.readOnly && (target.value.length == 0);
 		default:
 			return (/\bneedsfocus\b/).test(target.className);
 		}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -254,7 +254,8 @@
 				(target.type === 'date') || (target.type === 'time') ||
 				(target.type === 'datetime') || (target.type === 'datetime-local') ||
 				(target.type === 'tel') || (target.type === 'week') ||
-				(target.type === 'number')) && target.value.length > 0) {
+				(target.type === 'number') || (target.type === 'password') ||
+				(target.type === 'url')) && target.value.length > 0) {
 				return true;
 			}
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -250,7 +250,7 @@
 			}
 
 			// iOS 8.1: Focus on input (filled with text) pushes cursor out of bounds (issue #338)
-			if ((target.type === 'text') && target.value.length > 0) {
+			if (((target.type === 'text') || (target.type === 'email')) && target.value.length > 0) {
 				return true;
 			}
 

--- a/tests/338.html
+++ b/tests/338.html
@@ -17,6 +17,7 @@
 <body>
 	<p>Tap (not long tap) below textarea/input and confirm that cursor is moved end of contents.</p>
 	<textarea id="text_body">textarea string textarea string textarea string textarea string textarea string textarea string textarea string</textarea><br>
-	<input type="text" value="input text string input text string">
+	<input type="text" value="input text string input text string"><br>
+	<input type="email" value="input_text@example.com">
 </body> 
 </html>

--- a/tests/338.html
+++ b/tests/338.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html> 
+<html> 
+<head> 
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"> 
+<script type="application/javascript" src="../lib/fastclick.js"></script> 
+<script type="application/javascript">
+	window.addEventListener('load', function () {
+		new FastClick(document.body);
+	}, false);
+</script> 
+<style type="text/css">
+	textarea { width: 20em; height: 10em; }
+	input[type=text] { width: 20em; height 3em; }
+</style>
+<title>#338</title>
+</head> 
+<body>
+	<p>Tap (not long tap) below textarea/input and confirm that cursor is moved end of contents.</p>
+	<textarea id="text_body">textarea string textarea string textarea string textarea string textarea string textarea string textarea string</textarea><br>
+	<input type="text" value="input text string input text string">
+</body> 
+</html>

--- a/tests/338.html
+++ b/tests/338.html
@@ -18,6 +18,16 @@
 	<p>Tap (not long tap) below textarea/input and confirm that cursor is moved end of contents.</p>
 	<textarea id="text_body">textarea string textarea string textarea string textarea string textarea string textarea string textarea string</textarea><br>
 	<input type="text" value="input text string input text string"><br>
-	<input type="email" value="input_text@example.com">
+	<br>
+	E-mail: <input type="email" value="input_text@example.com"><br>
+	Date: <input type="date" value=""><br>
+	Time: <input type="time" value=""><br>
+	DateTime: <input type="datetime" value=""><br>
+	DateTime-Local: <input type="datetime-local" value=""><br>
+	Tel: <input type="tel" value=""><br>
+	Week: <input type="week" value=""><br>
+	Number: <input type="number" value=""><br>
+	Password: <input type="password" value=""><br>
+	URL: <input type="url" value=""><br>
 </body> 
 </html>


### PR DESCRIPTION
Fix #338 avoid moving cursor to the end of contents when focus on textarea/text
Fix: new input types need a real click
