### PR TITLE
Revert "Only blur before click on Android"

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -313,8 +313,7 @@
 		var clickEvent, touch;
 
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
-                // Limit to Android devices to avoid unnecessary breakage in code expecting blur after click (#350)
-		if (deviceIsAndroid && document.activeElement && document.activeElement !== targetElement) {
+		if (document.activeElement && document.activeElement !== targetElement) {
 			document.activeElement.blur();
 		}
 


### PR DESCRIPTION
Turns out we didn't need it.
Reverts turtlehat/fastclick#2
